### PR TITLE
Added support for VPCs that don't have hostnames

### DIFF
--- a/.ebextensions/efs-mount.config
+++ b/.ebextensions/efs-mount.config
@@ -65,9 +65,14 @@ files:
 
         mountpoint -q ${EFS_MOUNT_DIR}
         if [ $? -ne 0 ]; then
-            AZ=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
-            echo "mount -t nfs4 -o nfsvers=4.1 ${AZ}.${EFS_VOLUME_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}"
-            mount -t nfs4 -o nfsvers=4.1 ${AZ}.${EFS_VOLUME_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}
+            REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
+            MAC_ADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/mac)
+            SUBNET_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDRESS}/subnet-id)
+            MOUNTPOINT_QUERY="MountTargets[?SubnetId == '${SUBNET_ID}'].IpAddress | [0]"
+            MOUNTPOINT_IP=$(aws efs describe-mount-targets --region "${REGION}" --file-system-id ${EFS_VOLUME_ID} --query "${MOUNTPOINT_QUERY}" --output text)
+
+            echo "mount -t nfs4 -o nfsvers=4.1 ${MOUNTPOINT_IP}:/ ${EFS_MOUNT_DIR}"
+            mount -t nfs4 -o nfsvers=4.1 ${MOUNTPOINT_IP}:/ ${EFS_MOUNT_DIR}
             if [ $? -ne 0 ] ; then
                 echo 'ERROR: Mount command failed!'
                 exit 1


### PR DESCRIPTION
The example config doesn't work in VPCs that have DNS hostnames disabled. This change uses instance metadata + the aws cli to discover the EFS mount point's ip address without using a hostname.