### PR TITLE
Updated wp-config.php to use RDS_PORT

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -1,6 +1,6 @@
 <?php
 define('DB_NAME', $_SERVER['RDS_DB_NAME']);
-define('DB_USER', $_SERVER['RDS_USERNAME']);
+define('DB_USER', $_SERVER['RDS_HOSTNAME'] . ':' . $_SERVER['RDS_PORT']);
 define('DB_PASSWORD', $_SERVER['RDS_PASSWORD']);
 define('DB_HOST', $_SERVER['RDS_HOSTNAME']);
 define('DB_CHARSET', 'utf8');

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,8 +1,8 @@
 <?php
 define('DB_NAME', $_SERVER['RDS_DB_NAME']);
-define('DB_USER', $_SERVER['RDS_HOSTNAME'] . ':' . $_SERVER['RDS_PORT']);
+define('DB_USER', $_SERVER['RDS_USERNAME']);
 define('DB_PASSWORD', $_SERVER['RDS_PASSWORD']);
-define('DB_HOST', $_SERVER['RDS_HOSTNAME']);
+define('DB_HOST', $_SERVER['RDS_HOSTNAME'] . ':' . $_SERVER['RDS_PORT']);
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 define('AUTH_KEY',         $_SERVER['AUTH_KEY']);


### PR DESCRIPTION
The [instructions on the AWS support site](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/php-hawordpress-tutorial.html) tell you to set the RDS_PORT variable, but the config doesn't actually use it. This change uses it.